### PR TITLE
Changed deprecated ARWorldTrackingSessionConfiguration

### DIFF
--- a/FloorIsLava/ViewController.swift
+++ b/FloorIsLava/ViewController.swift
@@ -34,7 +34,7 @@ class ViewController: UIViewController, ARSCNViewDelegate {
         super.viewWillAppear(animated)
         
         // Create a session configuration
-        let configuration = ARWorldTrackingSessionConfiguration()
+        let configuration = ARWorldTrackingConfiguration()
         
         // Tell the session to automatically detect horizontal planes
         configuration.planeDetection = .horizontal

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Welcome to ARKit! This basic project setup shows how to start an AR session and 
 The `ARSession` gathers data from the world and processes it. Because we want to place objects on horizontal planes, we need to configure the session to detect them:
 
 ```swift
-let configuration = ARWorldTrackingSessionConfiguration()
+let configuration = ARWorldTrackingConfiguration()
 configuration.planeDetection = .horizontal
 ```
 


### PR DESCRIPTION
"ARWorldTrackingSessionConfiguration" is deprecated since iOS 11 came out of beta. This commit changes all occurrences in this project to the now appropriate "ARWorldTrackingConfiguration". 

https://developer.apple.com/documentation/arkit/arworldtrackingconfiguration